### PR TITLE
tcomment のキーマッピングを設定.

### DIFF
--- a/settings/keymapping/keymapping.vim
+++ b/settings/keymapping/keymapping.vim
@@ -31,7 +31,7 @@ nmap <C-x> :Ebd<CR>
 " 要: vim-gitgutter
 " └https://github.com/airblade/vim-gitgutter
 ""=========================================
-" gh で dif fをハイライトする
+" gh で diff をハイライトする
 nnoremap gh :GitGutterLineHighlightsToggle<CR>
 " gp でカーソル行のdiffを表示する
 nnoremap gp :GitGutterPreviewHunk<CR>
@@ -162,4 +162,11 @@ augroup fern-settings
   autocmd!
   autocmd FileType fern call s:fern_settings()
 augroup END
+
+""=========================================
+" tcomment のキーバインド
+" 要: tcomment
+" └https://github.com/tomtom/tcomment_vim
+""=========================================
+nnoremap <C-c><C-m> :TComment<CR>
 

--- a/vimrc
+++ b/vimrc
@@ -126,7 +126,6 @@ augroup END  " }}}
 ""=========================================
 " 各種設定ファイルの読み込み
 ""=========================================
-source <sfile>:h/.vim/settings/keymapping/keymapping.vim                " キーマッピング
 source <sfile>:h/.vim/settings/plugin/vim-plug-settings.vim             " プラグイン管理
 source <sfile>:h/.vim/settings/plugin/vim-gitgutter-settings.vim        " git 関連
 source <sfile>:h/.vim/settings/plugin/ale-settings.vim                  " ファイルフォーマット
@@ -134,4 +133,5 @@ source <sfile>:h/.vim/settings/plugin/markdown-preview-settings.vim     " マー
 source <sfile>:h/.vim/settings/plugin/vim-airline-settings.vim          " タブラインの設定
 source <sfile>:h/.vim/settings/program-language/javascript-settings.vim " JavaScript
 source <sfile>:h/.vim/settings/program-language/vue-js-settings.vim     " Vue.js
+source <sfile>:h/.vim/settings/keymapping/keymapping.vim                " キーマッピング
 


### PR DESCRIPTION
`<C-c><C-m>` でカーソル行をコメントアウトするキーマッピングを設定.