### PR TITLE
`vim.lsp.buf.formatting_sync` のエラーに対応.

### DIFF
--- a/neovim/lua/plugins-config/lsp-config.lua
+++ b/neovim/lua/plugins-config/lsp-config.lua
@@ -12,7 +12,7 @@ local on_attach = function(client, bufnr)
     vim.api.nvim_create_autocmd("BufWritePre", {
       group = vim.api.nvim_create_augroup("Format", { clear = true }),
       buffer = bufnr,
-      callback = function() vim.lsp.buf.formatting_seq_sync() end
+      callback = function() vim.lsp.buf.format() end
     })
   end
 end


### PR DESCRIPTION
当該メソッドが非推奨とのことなので `vim.lsp.buf.format` に移行.
参考:
https://dev.classmethod.jp/articles/eetann-okorare-neovim/