### PR TITLE
Fern上でファイル選択時にプレビューを表示する.

### DIFF
--- a/neovim/init.lua
+++ b/neovim/init.lua
@@ -51,3 +51,18 @@ vim.cmd([[
   augroup END
 ]])
 
+-- Fern 上でファイル選択時にプレビュー表示する
+vim.cmd([[
+  function! s:fern_settings() abort
+    nmap <silent> <buffer> p     <Plug>(fern-action-preview:toggle)
+    nmap <silent> <buffer> <C-p> <Plug>(fern-action-preview:auto:toggle)
+    nmap <silent> <buffer> <C-d> <Plug>(fern-action-preview:scroll:down:half)
+    nmap <silent> <buffer> <C-u> <Plug>(fern-action-preview:scroll:up:half)
+  endfunction
+
+  augroup fern-settings
+    autocmd!
+    autocmd FileType fern call s:fern_settings()
+  augroup END
+]])
+


### PR DESCRIPTION
## 背景
もともとプラグインは入れていたが、プレビューのための設定をしていなかった.