### PR TITLE
nvim-ts-autotag プラグインの設定を修正.

### DIFF
--- a/neovim/lua/plugins-config/tree-sitter-config.lua
+++ b/neovim/lua/plugins-config/tree-sitter-config.lua
@@ -1,10 +1,7 @@
 -- ##############################################
 -- tree-sitter
 -- ##############################################
-local status, ts = pcall(require, "nvim-treesitter.configs")
-if (not status) then return end
-
-ts.setup {
+require('nvim-ts-autotag').setup {
   highlight = {
     enable = true,
     disable = {},


### PR DESCRIPTION
`nvim-treesitter.configs.setup` が deprecated になったので下記の修正を行った.

```vim
-- 旧設定: Nvim Treesitter Setup
-- require('nvim-treesitter.configs').setup {
--   autotag = { enable = true }
-- }

-- 新設定: nvim-ts-autotag の setup を使う
require('nvim-ts-autotag').setup()
```